### PR TITLE
Make the example in the README run out-of-the-box

### DIFF
--- a/downstream-templates/python/README.md
+++ b/downstream-templates/python/README.md
@@ -47,8 +47,9 @@ print(token.get("access_token"))
 Once you get a token, you can create an instance of the iot-api client:
 
 ```python
-import iot_api_client
+import iot_api_client as iot
 from iot_api_client.rest import ApiException
+from iot_api_client.configuration import Configuration
 
 # configure and instance the API client
 client_config = Configuration(host="http://api-dev.arduino.cc/iot")
@@ -61,7 +62,7 @@ devices_api = iot.DevicesV2Api(client)
 try:
     resp = devices_api.devices_v2_list()
     print(resp)
-except iot.ApiException as e:
+except ApiException as e:
     print("Got an exception: {}".format(e))
 ```
 


### PR DESCRIPTION
This PR try to fix the imports to make the example work out of the box (i.e. copy/paste the code in a `.py` file and add a valid token).

Which class import directly from `iot_api_client` and which from one of the sub packages is pretty opinionated.. this is my best guess, feel free to adjust the import style.