### PR TITLE
Fix error status type to integer

### DIFF
--- a/spec/v2/swagger.yaml
+++ b/spec/v2/swagger.yaml
@@ -2764,10 +2764,10 @@ components:
             timestamp: 1458609066
           additionalProperties: true
         status:
-          type: string
-          description: the HTTP status code applicable to this problem, expressed as a
-            string value.
-          example: "400"
+          type: integer
+          description: the HTTP status code applicable to this problem
+          example: 400
+          format: int64
       description: Error response media type (default view)
       example:
         code: invalid_value
@@ -2775,7 +2775,7 @@ components:
         id: 3F1FKVRR
         meta:
           timestamp: 1458609066
-        status: "400"
+        status: 400
     propertiesValue:
       title: propertiesValue
       type: object


### PR DESCRIPTION
During my [iot-api go client](https://github.com/bcmi-labs/iot-api-client-go) tests I found that the generated client does not handle errors correctly, mainly because the swagger generated by goa has a wrong `error.status` type definition (`string` instead of `int`, but in the APIs actually uses  `int`).

So [I forced the custom swagger generator to use `int`](https://github.com/bcmi-labs/iot-api/pull/269/commits/d19014266d02cce7931937f80032f6cc1b1421cd), and regenerated the swagger file.

Can you please regenerate the client after merging this?