### PR TITLE
fix module name

### DIFF
--- a/config/languages/go_v2.json
+++ b/config/languages/go_v2.json
@@ -1,8 +1,7 @@
 {
     "gitUserId": "bcmi-labs",
     "gitRepoId": "iot-api-client-go",
-    "isGoSubmodule": true,
-    "packageName": "iot",
+    "isGoSubmodule": false,
     "packageVersion": "0.0.1",
     "withGoCodegenComment": true
 }


### PR DESCRIPTION
Prevent adding the package name to the base url, so that the module name generated is `github.com/bcmi-labs/iot-api-client-go`