### PR TITLE
Pass extra args to the Go client

### DIFF
--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -26,9 +26,8 @@ jobs:
           architecture: 'x64'
 
       - name: Install apigentools
-        # temporary use a fork while https://github.com/DataDog/apigentools/pull/46
-        # gets merged
-        run: pip install git+https://github.com/masci/apigentools.git@extra-args
+        # use master until 0.3.0 is released
+        run: pip install git+https://github.com/DataDog/apigentools.git@master
 
       - name: Generate clients
         env:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,9 +23,8 @@ jobs:
           architecture: 'x64'
 
       - name: Install apigentools
-        # temporary use a fork while https://github.com/DataDog/apigentools/pull/46
-        # gets merged
-        run: pip install git+https://github.com/masci/apigentools.git@extra-args
+        # use master until 0.3.0 is released
+        run: pip install git+https://github.com/DataDog/apigentools.git@master
 
       - name: Validate specfile
         run: apigentools validate


### PR DESCRIPTION
Pass `--type-mappings` to the Go client so we can override the way it handles the `Object` type and mitigate the issue with the ANY type fields.

While we wait upstream to merge a PR, we use the modified code so we don't block.