### PR TITLE
Only release when pushing version tags

### DIFF
--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -2,8 +2,8 @@ name: generate
 
 on:
   push:
-    branches:
-      - master
+    tags:
+      - '[0-9].[0-9]'
 
 jobs:
   push:


### PR DESCRIPTION
Instead of generating the clients at every merge on `master`, we trigger the workflow only if a tag in the form `x.y` is pushed (e.g. `2.0`).