### PR TITLE
pick ES6 templates explicitly

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -28,7 +28,7 @@
                 "v2"
             ],
             "version_path_template": "",
-            "upstream_templates_dir": "Javascript"
+            "upstream_templates_dir": "Javascript/es6"
         },
         "html2": {
             "github_repo_name": "iot-api-client-docs",


### PR DESCRIPTION
When using `openapi-generator -t templates/<lang>` (it's the case when you run `apigentools generate` without the `--builtin-templates`) the config option `useES6` seems to be ignored and the ES5 template located at https://github.com/OpenAPITools/openapi-generator/tree/v4.1.2/modules/openapi-generator/src/main/resources/Javascript is used instead. 

This PR points the upstream template explicitly to https://github.com/OpenAPITools/openapi-generator/tree/v4.1.2/modules/openapi-generator/src/main/resources/Javascript/es6