### PR TITLE
Add a custom setup.py script

### DIFF
--- a/downstream-templates/python/setup.py
+++ b/downstream-templates/python/setup.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+from setuptools import setup, find_packages  # noqa: H301
+
+version = {}
+with open("arduino_iot_rest/__init__.py") as fp:
+    exec(fp.read(), version)
+
+with open("README.md") as f:
+    long_description = f.read()
+
+NAME = "arduino-iot-client"
+REQUIRES = ["urllib3 >= 1.15", "six >= 1.10", "certifi", "python-dateutil"]
+
+setup(
+    name=NAME,
+    version=version["__version__"],
+    description="Iot API",
+    author_email="",
+    url="",
+    keywords=["OpenAPI", "OpenAPI-Generator", "Iot API"],
+    install_requires=REQUIRES,
+    packages=find_packages(exclude=["test", "tests"]),
+    include_package_data=True,
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+)


### PR DESCRIPTION
Package version isn't correctly set in the auto-generated `setup.py` but for some reasons it is correct in `__init__.py`. This PR adds a custom setup script picking up the right version.