### PR TITLE
Permission fix for generated clients and docs files

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -11,8 +11,8 @@ languages:
           - commandline:
             - chmod
             - -R
-            - 766
-            - {{version_output_dir}}
+            - 777
+            - "{{version_output_dir}}"
             description: fix permission for generated files
         templates:
           source:
@@ -38,8 +38,8 @@ languages:
           - commandline:
             - chmod
             - -R
-            - 766
-            - {{version_output_dir}}
+            - 777
+            - "{{version_output_dir}}"
             description: fix permission for generated files
         templates:
           patches:
@@ -70,8 +70,8 @@ languages:
           - commandline:
             - chmod
             - -R
-            - 766
-            - {{version_output_dir}}
+            - 777
+            - "{{version_output_dir}}"
             description: fix permission for generated files
         templates:
           source:
@@ -97,9 +97,9 @@ languages:
           - commandline:
             - chmod
             - -R
-            - 766
-            - {{version_output_dir}}
-            description: fix permission for generated files
+            - 777
+            - "{{version_output_dir}}"
+            description: Fix permission for generated files in {{version_output_dir}}
         templates:
           source:
             type: openapi-git

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -8,6 +8,12 @@ languages:
             - --type-mappings
             - object=interface{}
             description: Generate go code using openapi-generator
+          - commandline:
+            - chmod
+            - -R
+            - 766
+            - {{version_output_dir}}
+            description: fix permission for generated files
         templates:
           source:
             type: openapi-git
@@ -29,6 +35,12 @@ languages:
           - commandline:
             - function: openapi_generator_generate
             description: Generate doc using openapi-generator
+          - commandline:
+            - chmod
+            - -R
+            - 766
+            - {{version_output_dir}}
+            description: fix permission for generated files
         templates:
           patches:
             - template-patches/html2-arduino-css.patch
@@ -55,6 +67,12 @@ languages:
           - commandline:
             - function: openapi_generator_generate
             description: Generate js code using openapi-generator
+          - commandline:
+            - chmod
+            - -R
+            - 766
+            - {{version_output_dir}}
+            description: fix permission for generated files
         templates:
           source:
             type: openapi-git
@@ -76,6 +94,12 @@ languages:
           - commandline:
             - function: openapi_generator_generate
             description: Generate py code using openapi-generator
+          - commandline:
+            - chmod
+            - -R
+            - 766
+            - {{version_output_dir}}
+            description: fix permission for generated files
         templates:
           source:
             type: openapi-git


### PR DESCRIPTION
As the files are created by the tooling with `root` permission by the tooling containers, a `chmod` commandline step was added to the config to allow CI post operations.