### PR TITLE
Change ownership for generated files

### DIFF
--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Align permissions of generated code
         run: |
-          chown -R ${USER}:${USER} generated
+          sudo chown -R ${USER}:${USER} generated
 
       - name: Push client repos
         if: github.event_name == 'push'

--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -32,6 +32,10 @@ jobs:
           APIGENTOOLS_GIT_VIA_HTTPS_OAUTH_TOKEN: ${{ secrets.GH_PUSH_TOKEN }}
         run: apigentools generate --clone-repo
 
+      - name: Align permissions of generated code
+        run: |
+          chown -R ${USER}:${USER} generated
+
       - name: Push client repos
         if: github.event_name == 'push'
         env:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -9,9 +9,9 @@ languages:
             - object=interface{}
             description: Generate go code using openapi-generator
           - commandline:
-            - chmod
+            - chown
             - -R
-            - 777
+            - "1000"
             - "{{version_output_dir}}"
             description: fix permission for generated files
         templates:
@@ -36,9 +36,9 @@ languages:
             - function: openapi_generator_generate
             description: Generate doc using openapi-generator
           - commandline:
-            - chmod
+            - chown
             - -R
-            - 777
+            - "1000"
             - "{{version_output_dir}}"
             description: fix permission for generated files
         templates:
@@ -68,9 +68,9 @@ languages:
             - function: openapi_generator_generate
             description: Generate js code using openapi-generator
           - commandline:
-            - chmod
+            - chown
             - -R
-            - 777
+            - "1000"
             - "{{version_output_dir}}"
             description: fix permission for generated files
         templates:
@@ -95,9 +95,9 @@ languages:
             - function: openapi_generator_generate
             description: Generate py code using openapi-generator
           - commandline:
-            - chmod
+            - chown
             - -R
-            - 777
+            - "1000"
             - "{{version_output_dir}}"
             description: Fix permission for generated files in {{version_output_dir}}
         templates:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -8,12 +8,6 @@ languages:
             - --type-mappings
             - object=interface{}
             description: Generate go code using openapi-generator
-          - commandline:
-            - chown
-            - -R
-            - "1000"
-            - "{{version_output_dir}}"
-            description: fix permission for generated files
         templates:
           source:
             type: openapi-git
@@ -35,12 +29,6 @@ languages:
           - commandline:
             - function: openapi_generator_generate
             description: Generate doc using openapi-generator
-          - commandline:
-            - chown
-            - -R
-            - "1000"
-            - "{{version_output_dir}}"
-            description: fix permission for generated files
         templates:
           patches:
             - template-patches/html2-arduino-css.patch
@@ -67,12 +55,6 @@ languages:
           - commandline:
             - function: openapi_generator_generate
             description: Generate js code using openapi-generator
-          - commandline:
-            - chown
-            - -R
-            - "1000"
-            - "{{version_output_dir}}"
-            description: fix permission for generated files
         templates:
           source:
             type: openapi-git
@@ -94,12 +76,6 @@ languages:
           - commandline:
             - function: openapi_generator_generate
             description: Generate py code using openapi-generator
-          - commandline:
-            - chown
-            - -R
-            - "1000"
-            - "{{version_output_dir}}"
-            description: Fix permission for generated files in {{version_output_dir}}
         templates:
           source:
             type: openapi-git


### PR DESCRIPTION
The OpenAPI generator tool container generates new files using the user and permission defined in the container (root). 

This PR adds an additional permission alignment step to fix this side effect
