### PR TITLE
Fix js mapping error regression

### DIFF
--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -43,6 +43,8 @@ jobs:
           APIGENTOOLS_GIT_VIA_HTTPS_OAUTH_TOKEN: ${{ secrets.GH_PUSH_TOKEN }}
         run: |
           rm -rf generated/iot-client-js/docs/
+          rm -rf generated/iot-client-js/test/
+          rm -rf generated/iot-client-py/arduino_iot_rest/test/
           git config --global user.email "arduinobot@arduino.cc"
           git config --global user.name "ArduinoBot"
           apigentools push

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -54,6 +54,8 @@ languages:
         commands:
           - commandline:
             - function: openapi_generator_generate
+            - --type-mappings
+            - AnyType=Object
             description: Generate js code using openapi-generator
         templates:
           source:


### PR DESCRIPTION
This PR solves OpenAPI rgeneration regression for JS client (see [here](https://github.com/OpenAPITools/openapi-generator/pull/6091#issuecomment-627279544))

```
$npm run test                                                                                                                                                                                                   
                                                                                                                                                                                                                   
> @arduino/arduino-iot-client@1.3.0 test /home/rsora/code/projects/arduino/iot-client-js                                                                                                                           
> mocha --require @babel/register --recursive                                                                                                                                                                      
                                                                                                                                                                                                                   
internal/modules/cjs/loader.js:1017                                                                                                                                                                                
  throw err;                                                                                                                                                                                                       
  ^                                                                                                                                                                                                                
                                                                                                                                                                                                                   
Error: Cannot find module './AnyType'                                                                                                                                                                              
Require stack:  
```

In addition, generated tests are removed for py and js client as they are pretty useless, a PR will be opened in related client repos to implement simple integ tests