### PR TITLE
Force apigentools version to 1.1.0

### DIFF
--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -21,7 +21,7 @@ jobs:
           architecture: 'x64'
 
       - name: Install apigentools
-        run: pip install apigentools==1.1.0
+        run: pip install apigentools==1.1.0 # NB: If changes are needed, remeber to update the docker image accordingly at config/config.yaml 
 
       - name: Validate specfile
         run: apigentools validate
@@ -47,10 +47,3 @@ jobs:
           git config --global user.email "arduinobot@arduino.cc"
           git config --global user.name "ArduinoBot"
           apigentools push
-          
-      - name: Archive production artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: dist-without-markdown
-          path: |
-            generated

--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v1
         with:
-          python-version: '3.x'
+          python-version: '3.7.11'
           architecture: 'x64'
 
       - name: Install apigentools

--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -47,3 +47,10 @@ jobs:
           git config --global user.email "arduinobot@arduino.cc"
           git config --global user.name "ArduinoBot"
           apigentools push
+          
+      - name: Archive production artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: dist-without-markdown
+          path: |
+            generated

--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -21,7 +21,7 @@ jobs:
           architecture: 'x64'
 
       - name: Install apigentools
-        run: pip install apigentools
+        run: pip install apigentools==1.1.0
 
       - name: Validate specfile
         run: apigentools validate

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,3 +1,5 @@
+container_opts:
+  image: openapitools/openapi-generator:cli-v4.3.1
 languages:
   go:
     generation:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,5 +1,5 @@
 container_opts:
-  image: openapitools/openapi-generator:cli-v4.3.1
+  image: datadog/apigentools:1.1.0
 languages:
   go:
     generation:


### PR DESCRIPTION
### Motivation
Since the client generation wasn't working correctly, we discovered that `apigentools` has been configured to use the latest version of `openapi-generator`, which breaks the clients.

### Change description
- Force `python` version to `3.7.11`
- Force `apigentools` version to `1.1.0`
- Force `apigentools` related container version to `1.1.0`, which contains `openapi-generator` version `4.3.1`

### Additional Notes
<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

* [ ] PR address a single concern.
* [ ] PR title and description are properly filled.
* [ ] Changes will be merged in `master`.
* [ ] Changes are covered by tests.
* [ ] Logging is meaningful in case of troubleshooting.
* [ ] History is clean, commit messages are meaningful (see `CONTRIBUTING.md`) and are well formatted.