### PR TITLE
CI: Force python 3.7

### DIFF
--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v1
         with:
-          python-version: '3.7.11'
+          python-version: '3.7'
           architecture: 'x64'
 
       - name: Install apigentools


### PR DESCRIPTION
Force python version to `3.7`, instead of a specific minor version, in order to always take the last minor version.