### PR TITLE
[IOT-1730] Skip client side validation and fix packageName for python client

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -101,6 +101,8 @@ languages:
             - "{{version_output_dir}}"
             description: Copy shared assets in the generated folder
         templates:
+          patches:
+            - template-patches/python-configuration.patch
           source:
             type: openapi-git
             git_committish: "v4.3.1" # git committish to checkout before extracting the templates

--- a/config/languages/python_v2.json
+++ b/config/languages/python_v2.json
@@ -1,5 +1,5 @@
 {
-    "packageName": "arduino_iot_rest",
+    "packageName": "iot_api_client",
     "projectName": "arduino-iot-client",
     "packageVersion": "1.4.2",
     "generateSourceCodeOnly": true

--- a/downstream-templates/python/setup.py
+++ b/downstream-templates/python/setup.py
@@ -2,7 +2,7 @@
 from setuptools import setup, find_packages  # noqa: H301
 
 version = {}
-with open("arduino_iot_rest/__init__.py") as fp:
+with open("iot_api_client/__init__.py") as fp:
     exec(fp.read(), version)
 
 with open("README.md") as f:

--- a/template-patches/python-configuration.patch
+++ b/template-patches/python-configuration.patch
@@ -1,0 +1,16 @@
+diff --git a/python/configuration.mustache b/python/configuration.mustache
+index dceab63..b2d56ab 100644
+--- a/python/configuration.mustache
++++ b/python/configuration.mustache
+@@ -259,7 +259,7 @@ conf = {{{packageName}}}.Configuration(
+         """Adding retries to override urllib3 default value 3
+         """
+         # Disable client side validation
+-        self.client_side_validation = True
++        self.client_side_validation = False
+ 
+     def __deepcopy__(self, memo):
+         cls = self.__class__
+-- 
+2.17.1
+


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->
Python client users report two kinds of issues:

1) some methods are in the documentation but not available to the client
2) exception are raised when certain endpoints are called

The solution for the first problem is to fix the packageName setting it to the correct value
The solution to the second problem is less straightforward: typically the generated python client applies client-side validation to types (in requests and responses) following the set of rules described in the swagger file. But the swagger file generated by IoT-API lacks information. In particular, it is impossible to know when a type is required but can be null (required and nullable values). For this reason, the only safe way to handle requests and responses is to delegate the backend to verify the correctness of types. So the client-side validation has been disabled in the client code generation.

### Change description
<!-- What does your code do? -->
- Changed packageName to iot_api_client in order to reflect the name used in various examples
- Applied a patch to python openapi-generator templates in order to deactivate client side validation


### Additional Notes
<!-- Link any useful metadata: Jira task, GitHub issue, ... -->
https://arduino.atlassian.net/browse/IOT-1730

### Reviewer checklist

* [ ] PR address a single concern.
* [ ] PR title and description are properly filled.
* [ ] Changes will be merged in `master`.
* [ ] Changes are covered by tests.
* [ ] Logging is meaningful in case of troubleshooting.