### PR TITLE
[IOT-2478] Add security OAuth2 to dashboards endpoints

### DIFF
--- a/config/languages/go_v2.json
+++ b/config/languages/go_v2.json
@@ -3,6 +3,6 @@
     "gitRepoId": "iot-client-go",
     "isGoSubmodule": false,
     "packageName": "iot",
-    "packageVersion": "1.4.4",
+    "packageVersion": "1.4.5",
     "withGoCodegenComment": true
 }

--- a/config/languages/html2_v2.json
+++ b/config/languages/html2_v2.json
@@ -1,5 +1,5 @@
 {
     "packageName": "iot",
-    "packageVersion": "1.4.4",
+    "packageVersion": "1.4.5",
     "usePromises": true
 }

--- a/config/languages/javascript_v2.json
+++ b/config/languages/javascript_v2.json
@@ -1,8 +1,8 @@
 {
     "projectName": "@arduino/arduino-iot-client",
     "moduleName": "ArduinoIotClient",
-    "projectVersion": "1.4.4",
-    "packageVersion": "1.4.4",
+    "projectVersion": "1.4.5",
+    "packageVersion": "1.4.5",
     "usePromises": true,
     "licenseName":"GPLv3",
     "generateSourceCodeOnly": true

--- a/config/languages/python_v2.json
+++ b/config/languages/python_v2.json
@@ -1,6 +1,6 @@
 {
     "packageName": "iot_api_client",
     "projectName": "arduino-iot-client",
-    "packageVersion": "1.4.4",
+    "packageVersion": "1.4.5",
     "generateSourceCodeOnly": true
 }

--- a/spec/v2/swagger.yaml
+++ b/spec/v2/swagger.yaml
@@ -2082,6 +2082,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/error'
           description: Internal Server Error
+      security:
+      - oauth2: []
       summary: list dashboards_v2
       tags:
       - dashboards_v2
@@ -2129,6 +2131,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/error'
           description: Internal Server Error
+      security:
+      - oauth2: []
       summary: create dashboards_v2
       tags:
       - dashboards_v2
@@ -2170,6 +2174,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/error'
           description: Internal Server Error
+      security:
+      - oauth2: []
       summary: delete dashboards_v2
       tags:
       - dashboards_v2
@@ -2208,6 +2214,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/error'
           description: Internal Server Error
+      security:
+      - oauth2: []
       summary: show dashboards_v2
       tags:
       - dashboards_v2
@@ -2263,6 +2271,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/error'
           description: Internal Server Error
+      security:
+      - oauth2: []
       summary: update dashboards_v2
       tags:
       - dashboards_v2
@@ -2314,6 +2324,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/error'
           description: Internal Server Error
+      security:
+      - oauth2: []
       summary: requestAccess dashboards_v2
       tags:
       - dashboards_v2
@@ -2359,6 +2371,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/error'
           description: Internal Server Error
+      security:
+      - oauth2: []
       summary: listShares dashboards_v2
       tags:
       - dashboards_v2
@@ -2409,6 +2423,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/error'
           description: Internal Server Error
+      security:
+      - oauth2: []
       summary: share dashboards_v2
       tags:
       - dashboards_v2
@@ -2456,6 +2472,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/error'
           description: Internal Server Error
+      security:
+      - oauth2: []
       summary: deleteShare dashboards_v2
       tags:
       - dashboards_v2
@@ -2517,6 +2535,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/error'
           description: Internal Server Error
+      security:
+      - oauth2: []
       summary: link dashboards_v2
       tags:
       - dashboards_v2

--- a/spec/v2/swagger.yaml
+++ b/spec/v2/swagger.yaml
@@ -1303,6 +1303,7 @@ components:
           - phone
           - portenta_x8
           - opta
+          - giga
           type: string
         user_id:
           description: The user_id associated to the device. If absent it will be
@@ -1519,6 +1520,7 @@ components:
           - phone
           - portenta_x8
           - opta
+          - giga
           type: string
         user_id:
           description: The user_id associated to the device. If absent it will be


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->
A user of `iot-client-js` library created a PR to fix an issue when accessing the dashboards endpoints. The root cause of this issue is a missing security configuration related to OAuth2 authentication.
The original report is explicitly referring to version V2, but we should fix V1 as well, just in case someone is using the V1 version in their apps.

https://github.com/arduino/iot-client-js/pull/67

### Change description
<!-- What does your code do? -->
Added a specific security setting in Arduino's `iot-api` library and updated swagger.yml accordingly

### Additional Notes
<!-- Link any useful metadata: Jira task, GitHub issue, ... -->
https://github.com/arduino/iot-client-js/pull/67
https://arduino.atlassian.net/browse/IOT-2478 (Arduino internal issue tracker)

### Reviewer checklist

* [x] PR address a single concern.
* [x] PR title and description are properly filled.
* [x] Changes will be merged in `master`.
* [ ] Changes are covered by tests.
* [ ] Logging is meaningful in case of troubleshooting.
* [x] History is clean, commit messages are meaningful (see `CONTRIBUTING.md`) and are well formatted.
* [ ] Mentioned the Analytics team when there are schema changes.
